### PR TITLE
Move sell mode button into build area

### DIFF
--- a/index.html
+++ b/index.html
@@ -84,87 +84,88 @@
                     <button class="tab-btn" data-tab="policies">Policies</button>
                 </div>
 
-                <!-- Tab Content Areas -->
-                <div id="tab-content">
-                    <!-- Manpower Tab -->
-                    <div id="tab-manpower" class="tab-pane active">
-                        <div class="build-menu">
-                            <button class="build-btn" data-type="engineer">
-                                <span class="btn-icon">👓</span>
-                                <div class="btn-label">
-                                    <span class="btn-name">Jr. Dev</span>
-                                    <span class="btn-price">$100</span>
-                                </div>
-                            </button>
-                            <button class="build-btn" data-type="senior_engineer">
-                                <span class="btn-icon">👴</span>
-                                <div class="btn-label">
-                                    <span class="btn-name">Sr. Dev</span>
-                                    <span class="btn-price">$300</span>
-                                </div>
-                            </button>
-                            <button class="build-btn" data-type="marketing">
-                                <span class="btn-icon">📢</span>
-                                <div class="btn-label">
-                                    <span class="btn-name">Sales</span>
-                                    <span class="btn-price">$150</span>
-                                </div>
-                            </button>
-                            <button class="build-btn" data-type="pm">
-                                <span class="btn-icon">📅</span>
-                                <div class="btn-label">
-                                    <span class="btn-name">PM</span>
-                                    <span class="btn-price">$250</span>
-                                </div>
-                            </button>
+                <!-- Build Row combines build options and sell mode control -->
+                <div id="build-row">
+                    <!-- Tab Content Areas -->
+                    <div id="tab-content">
+                        <!-- Manpower Tab -->
+                        <div id="tab-manpower" class="tab-pane active">
+                            <div class="build-menu">
+                                <button class="build-btn" data-type="engineer">
+                                    <span class="btn-icon">👓</span>
+                                    <div class="btn-label">
+                                        <span class="btn-name">Jr. Dev</span>
+                                        <span class="btn-price">$100</span>
+                                    </div>
+                                </button>
+                                <button class="build-btn" data-type="senior_engineer">
+                                    <span class="btn-icon">👴</span>
+                                    <div class="btn-label">
+                                        <span class="btn-name">Sr. Dev</span>
+                                        <span class="btn-price">$300</span>
+                                    </div>
+                                </button>
+                                <button class="build-btn" data-type="marketing">
+                                    <span class="btn-icon">📢</span>
+                                    <div class="btn-label">
+                                        <span class="btn-name">Sales</span>
+                                        <span class="btn-price">$150</span>
+                                    </div>
+                                </button>
+                                <button class="build-btn" data-type="pm">
+                                    <span class="btn-icon">📅</span>
+                                    <div class="btn-label">
+                                        <span class="btn-name">PM</span>
+                                        <span class="btn-price">$250</span>
+                                    </div>
+                                </button>
+                            </div>
+                        </div>
+
+                        <!-- Facilities Tab -->
+                        <div id="tab-facilities" class="tab-pane">
+                            <div class="build-menu">
+                                <button class="build-btn" data-type="server">
+                                    <span class="btn-icon">💾</span>
+                                    <div class="btn-label">
+                                        <span class="btn-name">Server</span>
+                                        <span class="btn-price">$500</span>
+                                    </div>
+                                </button>
+                                <button class="build-btn" data-type="pantry">
+                                    <span class="btn-icon">☕</span>
+                                    <div class="btn-label">
+                                        <span class="btn-name">Pantry</span>
+                                        <span class="btn-price">$300</span>
+                                    </div>
+                                </button>
+                                <button class="build-btn" data-type="conference_room">
+                                    <span class="btn-icon">🤝</span>
+                                    <div class="btn-label">
+                                        <span class="btn-name">Meeting</span>
+                                        <span class="btn-price">$1000</span>
+                                    </div>
+                                </button>
+                                <button class="build-btn" data-type="plant">
+                                    <span class="btn-icon">🪴</span>
+                                    <div class="btn-label">
+                                        <span class="btn-name">Plant</span>
+                                        <span class="btn-price">$50</span>
+                                    </div>
+                                </button>
+                            </div>
+                        </div>
+
+                        <!-- Policies Tab -->
+                        <div id="tab-policies" class="tab-pane">
+                            <div id="policies-list">
+                                <!-- Policy Items injected by JS -->
+                            </div>
                         </div>
                     </div>
 
-                    <!-- Facilities Tab -->
-                    <div id="tab-facilities" class="tab-pane">
-                        <div class="build-menu">
-                            <button class="build-btn" data-type="server">
-                                <span class="btn-icon">💾</span>
-                                <div class="btn-label">
-                                    <span class="btn-name">Server</span>
-                                    <span class="btn-price">$500</span>
-                                </div>
-                            </button>
-                            <button class="build-btn" data-type="pantry">
-                                <span class="btn-icon">☕</span>
-                                <div class="btn-label">
-                                    <span class="btn-name">Pantry</span>
-                                    <span class="btn-price">$300</span>
-                                </div>
-                            </button>
-                            <button class="build-btn" data-type="conference_room">
-                                <span class="btn-icon">🤝</span>
-                                <div class="btn-label">
-                                    <span class="btn-name">Meeting</span>
-                                    <span class="btn-price">$1000</span>
-                                </div>
-                            </button>
-                            <button class="build-btn" data-type="plant">
-                                <span class="btn-icon">🪴</span>
-                                <div class="btn-label">
-                                    <span class="btn-name">Plant</span>
-                                    <span class="btn-price">$50</span>
-                                </div>
-                            </button>
-                        </div>
-                    </div>
-
-                    <!-- Policies Tab -->
-                    <div id="tab-policies" class="tab-pane">
-                        <div id="policies-list">
-                            <!-- Policy Items injected by JS -->
-                        </div>
-                    </div>
-                </div>
-
-                <!-- Global Controls -->
-                <div id="controls">
-                    <button id="delete-mode-btn">🗑️ Sell Mode</button>
+                    <!-- Sell Mode Control -->
+                    <button id="delete-mode-btn" class="sell-mode-btn">🗑️ Sell Mode</button>
                 </div>
             </div>
 

--- a/src/style.css
+++ b/src/style.css
@@ -136,6 +136,7 @@ body {
   width: 100%;
   display: flex;
   justify-content: center;
+  flex: 1;
 }
 
 .tab-pane {
@@ -316,23 +317,35 @@ body {
   color: #000;
 }
 
-#controls {
-  background: rgba(0, 0, 0, 0.7);
-  padding: 10px;
-  border-radius: 10px;
-  backdrop-filter: blur(5px);
-  margin-left: 10px;
+#build-row {
+  display: flex;
+  align-items: stretch;
+  gap: 10px;
+  width: 100%;
+  justify-content: center;
 }
+
 
 #delete-mode-btn {
   background: var(--danger-color);
   color: white;
   border: none;
   padding: 12px 18px;
-  border-radius: 5px;
+  border-radius: 10px;
   cursor: pointer;
-  font-weight: 600;
+  font-weight: 700;
   transition: all 0.3s ease;
+  align-self: stretch;
+  min-width: 140px;
+  box-shadow: 0 10px 25px rgba(255, 68, 68, 0.2);
+}
+
+.sell-mode-btn {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: 10px;
+  font-size: 1rem;
 }
 
 #delete-mode-btn:hover {
@@ -662,6 +675,16 @@ body {
 
   .progress-bar-bg {
     width: 100px;
+  }
+
+  #build-row {
+    flex-direction: column;
+    align-items: center;
+  }
+
+  #delete-mode-btn {
+    width: 100%;
+    min-width: auto;
   }
 
   /* Bottom bar adjustments */


### PR DESCRIPTION
## Summary
- reposition the Sell Mode control into the build row alongside unit purchase buttons to save space
- add styling adjustments so the new layout aligns with build menus and adapts on smaller screens

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6923b9abd1bc832b943c6429826355f3)